### PR TITLE
Added more detailed specification of the protocol

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -1,0 +1,388 @@
+# io-homecontrol commands
+
+## Commands
+
+A command is built as follow:
+
+* A command ID (1 byte) identifying the desired action
+* Command parameters
+
+## Command parameter types
+
+### ACEI
+
+According to the io-homecontrol shared library, it is composed of one byte as following (bit positions in header):
+
+|            7-5  |                4-3      |                    2-1      |   0 |
+| :-------------: | :---------------------: | :-------------------------: | :-: |
+|  Priority level | Priority Service Number | Extended information number |   1 |
+
+The LSB must be 1, it is not considered valid if this bit is set to 0.
+
+### Originator
+
+The originator parameter specifies what fired the command:
+
+* 00: Local user?
+* 01: User
+* 02: Rain
+* 03: Timer
+* 04: Security
+* 05: UPS?
+* 06: SFC?
+* 07: LSC?
+* 08: SAAC? (looks like to be the default originator)
+* 09: Wind
+* 0B: External access
+* C8: Unknown
+* FF: Emergency
+* Other?
+
+### Main parameter
+
+TARGET = 53504 = 0xD100
+CURRENT = 53760 = 0xD200
+DEFAULT = 54016 = 0xD300
+IGNORE = 54272 = 0xD400
+
+### Manufacturer
+
+Manufacturers have their own ID:
+
+* Public: 00
+* Velux: 01
+* Somfy: 02
+* Honeywell: 03
+* Hörmann: 04
+* ASSA ABLOY: 05
+* Niko: 06
+* Window Master: 07
+* Renson: 08
+* CIAT: 09
+* Secuyou: 0A
+* OVERKIZ: 0B
+* Atlantic Group: 0C
+* Zehnder Group: 0D
+
+### Node type
+
+#### Actuators
+
+* INTERIOR_VENETIAN_BLIND = 1
+* ROLLING_SHUTTER = 2
+* VERTICAL_EXTERIOR_AWNING = 3
+* WINDOW_OPENER = 4
+* GARAGE_DOOR_OPENER = 5
+* LIGHT = 6
+* GATE_OPENER = 7
+* ROLLING_DOOR_OPENER = 8
+* DOOR_LOCK = 9
+* INTERIOR_VERTICAL_BLIND = 10
+* SCD = 11,
+* BEACON = 12
+* DUAL_ROLLING_SHUTTER = 13
+* TEMPERATURE_CONTROL_INTERFACE = 14
+* ON_OFF_SWITCH = 15
+* HORIZONTAL_AWNING = 16
+* EXTERIOR_VENETIAN_BLIND = 17
+* LOUVRE_BLIND = 18
+* CURTAIN_TRACK = 19
+* VENTILATION_POINT = 20
+* EXTERIOR_HEATING = 21
+* HEAT_PUMP = 22
+* INTRUSION_ALARM_SYSTEM = 23
+* SWINGING_SHUTTER = 24
+* SLIDING_WINDOW = 27
+* ZONE_CONTROL_GENERATOR = 28
+* BIOCLIMATIC_PERGOLA = 29
+* INDOOR_SIREN = 30
+* DOMESTIC_HOT_WATER = 51
+* ELECTRICAL_HEATER = 52
+* HEAT_RECOVERY_VENTILATION = 53
+* CENTRAL_HOUSE_CONTROL = 255
+* REMOTE_CONTROLLER = 1023
+
+#### Sensors
+
+
+* TEMPERATURE_INSIDE_SENSOR = 2
+* TEMPERATURE_OUTSIDE_SENSOR = 3
+* PRESSURE_SENSOR = 5
+* LIGHT_OUTSIDE_SENSOR = 11
+* CUMULATED_GAS = 12
+* WATER_CONSUMPTION_SENSOR = 13
+* THERMAL_CONSUMPTION_SENSOR = 14
+* ELECTRIC_CONSUMPTION_SENSOR = 15
+* SMOKE_SENSOR = 128
+* OPENING_DETECTOR = 133
+* MOTION_SENSOR = 134
+* MULTITYPE_SENSOR = 254
+
+#### Device classes
+
+* ACTUATOR = 0
+* SENSOR = 1
+* STACK = 2
+* SLAVE = 3
+* MASTER = 4
+* BEACON = 5
+* CONTROLLER = 6
+
+## Command IDs
+
+### 00: Activate func
+
+Command ID: 0x00 (1 byte)
+Command originator (1 byte)
+ACEI (1 byte)
+Main parameter (2 bytes)
+Functional parameter 1 (1 byte)
+Functional parameter 2 (1 byte)
+
+Example:
+```
+00 01 43 d2 00 00 00
+```
+Command ID=0, Originator=1 (User), ACEI=0x43, MainParam=0xd200 (Current), FP1=0, FP2=0
+
+### 01: Activate mode
+
+Command ID: 0x01 (1 byte)
+Command originator (1 byte)
+ACEI (1 byte)
+Mode number (1 byte)
+Mode parameter (1 byte)
+Unknown (1 byte)
+Unknown (1 byte)
+
+### 03: Unknown
+
+Command ID: 0x03 (1 byte)
+Data? (3-6 bytes)
+
+### 04: Unknown
+
+Command ID: 0x04 (1 byte)
+Data? (6-20 bytes)
+
+**Note:** this frame does not have any HMAC
+
+### 0c: Unknown
+
+Command ID: 0x0c (1 byte)
+Data? (4 bytes)
+
+**Note:** this frame does not have any HMAC
+
+### 20: Private protocol
+
+Command ID: 0x20 (1 byte)
+Manufacturer ID (1 byte)
+Data
+
+Example:
+```
+20 02 ff0143000c0000
+```
+Command ID=0x20, Manufacturer=0x02 (SOMFY), Data=ff0143000c0000
+
+### 21: Private protocol answer
+
+Command ID: 0x21 (1 byte)
+Manufacturer ID (1 byte)
+Data
+
+### 28: Discover
+
+Command ID: 0x28 (1 byte)
+
+**Note:** this frame does not have any HMAC
+
+### 29: Discover answer
+
+Command ID: 0x29 (1 byte)
+Node type and subtype (2 bytes): type on 10 bits and subtype on the remainer
+    Node type = (field >> 6) & 1023
+    Node subtype = field & 63
+Node address (3 bytes)
+Manufacturer ID (1 byte)
+Multi info byte (1 byte)
+Timestamp (2 bytes)
+
+**Note:** the frame does not have any HMAC
+
+Example:
+```
+29 ffc0 XXXXXX 0c cc 0000
+```
+Command ID = 0x29, node type = 1023 (REMOTE_CONTROLLER?), node subtype = 0, node address = XXXXXX, manufacturer = Atlantic, multi info byte = 0xcc, timestamp = 0
+
+
+### 2a: Possible specialized discover
+
+Command ID: 0x2a (1 byte)
+?? (12 bytes)
+
+**Note 1:** observed after launching the box in discover mode
+**Note 2:** the frame does not have any HMAC
+
+### 2b: Possible specialized discover answer
+
+Parameters are similar to 0x29
+
+Command ID: 0x2b (1 byte)
+Node type and subtype (2 bytes)
+    Node type = (field >> 6) & 1023
+    Node subtype = field & 63
+Node address (3 bytes)
+Manufacturer ID (1 byte)
+Multi info byte (1 byte)
+Timestamp (2 bytes)
+
+**Note:** the frame does not have any HMAC
+
+```
+2b 0d01 XXXXXX 0c cc 0fb8
+```
+Command ID = 0x2b, node type = 52 (ELECTRICAL_HEATER), node subtype = 1, node address = XXXXXX, manufacturer = Atlantic, multi info byte = 0xcc, timestamp = 4024
+
+### 2c: Unknown
+
+Command ID = 0x2c
+
+No parameter. Some sort of discover ack? Sent by device, not box.
+
+**Note:** the frame does not have any HMAC
+
+### 2e: Unknown
+
+Command ID: 0x2e (1 byte)
+?? (1 byte), 00 (TaHoma sent) and 02 (Sauter heater) observed
+
+**Note 1:** observed after launching the box in discover mode
+**Note 2:** the frame does not have any HMAC
+
+Example:
+```
+2e 00
+```
+
+### 30: Send 1W key?
+
+Command ID: 0x30 (1 byte)
+16-byte random data (encrypted key?)
+Manufacturer ID (1 byte)
+?? (1 byte)
+Sequence number (2 bytes)
+
+**Note 1:** this frame does not have any HMAC
+**Note 2:** the address seems to be derived from the last 3 bytes of the encrypted key. The encrypted key is specified in the QR code printed on the 1W controller label.
+
+Example:
+```
+30 e79410dcb5dcb9f2d4c0d13c2f485b37 02 01 0c25
+```
+Command ID=0x30, key?: e79410dcb5dcb9f2d4c0d13c2f485b37, manufacturer ID=0x02, ??=0x01, Sequence number=0x0c25
+
+### 31: Unknown
+
+Command ID: 0x31 (1 byte)
+
+No parameter.
+**Note:** this frame does not have any HMAC
+
+
+### 36: Unknown
+
+Command ID: 0x36 (1 byte)
+
+No parameter.
+
+**Note:** this frame does not have any HMAC
+
+### 38: Launch key transfer
+
+Command ID: 0x38 (1 byte)
+Data (6 bytes) same length as HMAC?
+
+
+### 39: Remove 1W controller
+
+Command ID: 0x39 (1 byte)
+??: (1 byte): 0x00 observed
+
+### 3d: Unknown
+
+Command ID: 0x3d (1 byte)
+Data? (6 bytes)
+
+### 46: Unknown
+
+Command ID: 0x46 (1 byte)
+Data? (9 bytes)
+
+### 47: Unknown
+
+Command ID: 0x47 (1 byte)
+?? (1 byte)
+Data (4 bytes)
+
+### 48: Unknown
+
+Command ID: 0x48 (1 byte)
+Data? (9 bytes)
+
+### 4a: Unknown
+
+Command ID: 0x4a (1 byte)
+Data? (3-13 bytes)
+
+### 4b: Large data answer?
+
+Command ID: 0x4b (1 byte)
+?? (1 byte)
+Sequence number of data (1 byte)
+Data (1-18 bytes)
+
+This command is chained to send large numbers of bytes.
+
+### 50: Get name
+
+Command ID: 0x50 (1 byte)
+
+No parameter.
+
+**Note:** this frame does not have any HMAC
+
+### 51: Get name answer
+
+Command ID: 0x51 (1 byte)
+Name (16 bytes ASCII)
+
+**Note:** this frame does not have any HMAC
+
+### 52: Write name
+
+Command ID: 0x52 (1 byte)
+Data (16 bytes) ASCII
+
+**Note:** this frame does not have any HMAC
+
+Example:
+```
+52 54657374000000000000000000000000
+```
+Command ID=0x52, Data="Test"
+
+### 54: Get general info 1
+
+Command ID: 0x54 (1 byte)
+
+### 56: Get general info 2
+
+Command ID: 0x56 (1 byte)
+
+### fe: Unknown
+
+Command ID: 0xfe (1 byte)
+?? (1 byte)

--- a/LinkLayer.md
+++ b/LinkLayer.md
@@ -1,0 +1,105 @@
+# io-homecontrol link layer specification
+
+## io protocol frame
+
+This is the standard io-homecontrol frame (byte positions in the header).
+
+|              1 |              2 |                 3-5 |            6-8 |          9 | variable | (N-1)-N |
+| :------------: | :------------: | :-----------------: | :------------: | :--------: | :------: | :-----: |
+| Control byte 1 | Control byte 2 | Destination address | Sender address | Command ID |   DATA   |     CRC |
+
+## Control byte 1
+
+The control byte 1 gives basic information about the frame (bit positions in the header):
+
+|  7  |   6   |       5       |                        4-0  |
+| :-: | :---: | :-----------: | :-------------------------: |
+| End | Start | Protocol mode |         Frame length        |
+
+End:
+
+* 0 this is not the last frame of the session
+* 1 this is the last frame of the session
+
+Start:
+
+* 0 this is not the first frame of the session
+* 1 this is the first frame of the session
+
+Protocol mode:
+
+* 0 Two-way
+* 1 One-way
+
+Frame length:
+
+Length of the frame in bytes, not including the first control byte and the CRC
+
+## Control byte 2
+
+This control byte gives more information on the frame and the device themselves (bit positions in the header):
+
+|     7      |   6    |       5        |  4  |  3  |  2  |           1-0    |
+| :--------: | :----: | :------------: | :-: | :-: | :-: | :--------------: |
+| Use beacon | Routed | Low power mode |  ?  |  ?  |  ?  | Protocol version |
+
+Use beacon (allow routing the frame through the mesh network):
+
+* 0 do not use beacon
+* 1 use beacon
+
+Routed indicates if the frame has already been routed through a beacon:
+
+* 0 frame has not been routed so far
+* 1 frame has been routed
+
+Low power mode indicates if a frame is sent to a device operating in low power mode:
+
+* 0 the destination device is not in low power mode
+* 1 the destination device is in low power mode
+
+Bits 4, 5 and 6 are unknown
+
+## Addresses
+
+Addresses are 3 bytes long and can range from `01 00 00` to ̀`ff ff ff`.
+
+### Destination address
+
+Addresses are 3 bytes long.
+
+̀`00 00 3f` is broadcast
+
+### Sender address
+
+Addresses are 3 bytes long.
+
+## Command ID
+
+Standard io-homecontrol command id. See [Commands](Commands.md) for command id reference.
+
+## Data
+
+Depending on the frame type it can correspond to raw data, io-homecontrol command parameters or manufacturer-specific data.
+
+## CRC
+
+After the payload, there is a 16-bit CRC with polynomial 0x(1)8408 over the data packet (i.e. length byte + payload). The CRC's initial value is 0 and it does not employ an XOR/NOT. The least significant byte of the CRC is transmitted first.
+
+## Stack system key
+
+Each two-ways controller has a stack or system key. This is an AES-128 key used to sign io frames with the trailing MAC. The key generation on Kizboxes is insecure because it relies on the lua math.random :
+
+```lua
+-- seed
+kizbox_id = "xxxx-xxxx-xxxx" -- Kizbox serial
+math.randomseed(tonumber(string.gsub("1" .. kizbox_id, "-", "")) - os.time())
+-- key generation
+key = {}
+keySize = 16 -- 128 bits
+for i = 1, keySize do
+    key[i] = math.random(0, 255)
+end
+```
+
+This mechanism only leaves roughly 31,536,000 keys possible if the serial number of the TaHoma and the year of setup are known (other calls to math.random are made so the actual number may be a bit above this figure but once the seed and the number of times math.random is called are figured out by an attacker, they can completly determine the key).

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ This project should document every bit of information about io-homecontrol and m
   - WiFi instead of 868 MHz ISM Band > io-homecontrol iomecontrol iomecntrl
 - [ ] Possible to flash Velux/Somfy firmware onto Ikea remotes?
 
+## Detailed Information
+
+Covered in the following documents are the details of the io-homecontrol protocols
+
+* [Radio](Radio.md)
+* [Link Layer](LinkLayer.md)
+* [Commands](Commands.md)
+
 ## Basic Information
 
 There is a low level lib thats accessable to members of the io-homecontrol board.
@@ -119,6 +127,7 @@ Overview of official hardware (eg. transceiver chips, MCUs, SOCs, remote control
   - Rexel Energeasy Connect
   - Somfy Connexoon
   - Somfy TaHoma
+    - SI4461 + STM32F101RCT6
 - Other Companies
   - SecuYou
   - Assa Abloy

--- a/Radio.md
+++ b/Radio.md
@@ -4,13 +4,25 @@
 
 The io-homecontrol protocol is constructed on 2-FSK encoded frames.
 
-There are 3 channels as following:
+- Channels:
+  - 1: 868.25 MHz (868.00 MHz – 868.60 MHz)
+  - 2: 868.95 MHz (868.70 MHz – 869.20 MHz)
+  - 3: 869.85 MHz (869.70 MHz – 870.00 MHz)
+- Band (Narrow): 12.5/25 kHz (> add 50 kHz rtl_433 Range)
+- Deviation: 20 kHz (> add another 40 kHz)
+- Data/Baud Rate: 38.4 kbps (bandwidth of 38,4kbs with 2-FSK)
+- Encoding: NRZ
+- Modulation: 2-FSK
+- Standards: IEEE 802.15.4(g) / ETSI-300-200
+- Modes: Master, Slave, Beacon
+- Checks: CRC, preamble, start byte
+- Encoding (data): UART
 
-* 868.25MHz
-* 868.95MHz
-* 869.85MHz
-
-The data is transmitted with a baud rate of 38400bauds (on 2-FSK that's a bandwith of 38,4kbs).
+|     Radio      | Channel |   Start    |    End     |    Base    |
+| :------------: | :-----: | :--------: | :--------: | :--------: |
+| io-homecontrol |    1    | 868.00 MHz | 868.60 MHz | 868.25 MHz |
+| io-homecontrol |    2    | 868.70 MHz | 869.20 MHz | 868.95 MHz |
+| io-homecontrol |    3    | 869.70 MHz | 870.00 MHz | 869.85 MHz |
 
 ## Raw data sending
 

--- a/scripts/ioHexFrameParser.py
+++ b/scripts/ioHexFrameParser.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+import sys
+import struct
+import binascii
+
+#### io-homecontrol definitions
+
+class IoFrame:
+
+  Oneway = "One-Way"
+  TwoWay = "Two-Way"
+
+  def __init__(self, raw=None):
+    self.raw = raw
+    self.control_byte1 = 0
+    self.control_byte2 = 0
+    self.length = 0
+    self.end_frame = False
+    self.start_frame = False
+    self.protocol_mode = IoFrame.Oneway
+    self.from_addr = 0
+    self.to_addr = 0
+    self.use_beacon = False
+    self.routed = False
+    self.lpm = False
+    self.protocol_version = 0
+    self.commandid = 0
+    self.commanddata = None
+    self.seqnum = 0
+    self.crc = 0
+    if raw is not None:
+      self.parse_raw(raw)
+
+  def parse_raw(self, rframe):
+    if len(rframe) < 5:
+      raise ValueError("An io frame has at least control bytes, command ID and CRC")
+    self.raw = rframe
+    self.control_byte1 = rframe[0]
+    self.control_byte2 = rframe[1]
+    self.length = self.control_byte1 & 0x1f
+    if self.length > len(rframe):
+      raise ValueError("Frame is incomplete (bytes missing)")
+    self.end_frame = True if rframe[0] & 0x80 != 0 else False
+    self.start_frame = True if rframe[0] & 0x40 != 0 else False
+    self.protocol_mode = IoFrame.Oneway if rframe[0] & 0x20 != 0 else IoFrame.TwoWay
+    self.from_addr = rframe[2:5]
+    self.to_addr = rframe[5:8]
+    self.use_beacon = True if rframe[1] & 0x80 != 0 else False
+    self.routed = True if rframe[1] & 0x40 != 0 else False
+    self.lpm = True if rframe[1] & 0x20 != 0 else False
+    self.protocol_version = rframe[1] & 0x03
+    self.commandid = rframe[8]
+    self.commanddata = rframe[9:self.length+1]
+    self.crc = rframe[self.length+1:]
+
+  def __str__(self) -> str:
+    return_string = ""
+    if self.length != 0:
+      return_string += f"io-homecontrol frame: length={self.length}, from_addr={binascii.hexlify(self.from_addr)}, to_addr={binascii.hexlify(self.to_addr)}\n"
+      return_string += f"  control byte 1=0x{self.control_byte1:02x} ("
+      return_string += f"first frame={self.start_frame}, last frame={self.end_frame}, "
+      return_string += f"protocol mode = {self.protocol_mode})\n"
+      return_string += f"  control byte 2=0x{self.control_byte2:02x} ("
+      return_string += f"use beacon={self.use_beacon}, routed={self.routed}, low power mode={self.lpm}, "
+      return_string += f"protocol version={self.protocol_version})\n"
+      return_string += f"  command ID=0x{self.commandid:02x}\n"
+      return_string += f"  command data={binascii.hexlify(self.commanddata)}\n"
+      return_string += f"  CRC={binascii.hexlify(self.crc)}\n"
+      return return_string
+    else:
+      return "None"
+
+def main(args):
+  if len(args) < 2 or len(args) == 2 and args[1] == "-f":
+    print(f"Usage: {args[0]} <hex encoded frame or -f file>")
+    return
+
+  raw_frames = []
+  if args[1] == "-f":
+    with open(args[2], "rt") as f:
+      for line in f:
+        raw_frames.append(line)
+  else:
+    raw_frames.append(''.join(sys.argv[1:]))
+
+  for rframe in raw_frames:
+    frame = IoFrame(bytes.fromhex(rframe))
+    print(frame)
+
+
+if __name__ == "__main__":
+  main(sys.argv)


### PR DESCRIPTION
Hi,

I managed to tap directly on the serial interfaces used by the STM32 on the TaHoma box to send frames through the SI4461 chip. Sure enough, when matching on frame preambles, we can retrieve frames from the box.

Using some guessing and reverse engineering on the various firmware and libraries, I was able to pull some information on the application protocol.

Note that I saw frames unauthenticated. It seems that authentication is not mandatory with io-homecontrol. In these cases, I do not see any sequence number or HMAC...