### PR TITLE
add kaitai-schema

### DIFF
--- a/scripts/io-homecontrol.ksy
+++ b/scripts/io-homecontrol.ksy
@@ -1,169 +1,112 @@
 meta:
-  id: iohomecontrol_protocol_body
-  title: io-homecontrol Frame
-  endian: le
+  id: io-homecontrol
+  title: io-homecontrol packet
   license: CC0-1.0
-  ks-version: 0.8
-  imports:
-    - /network/protocol_body
-    - /network/ipv4_packet
-    - /network/tcp_segment
-    - /network/udp_datagram
-    - /network/icmp_packet
-doc: |
-  Protocol body represents particular payload on transport level (OSI layer 4).
-
-  Typically this payload in encapsulated into network level (OSI layer 3) packet, which includes "protocol number" field that would be used
-  to decide what's inside the payload and how to parse it. Thanks to IANA's standardization effort, multiple network level use the same
-  IDs for these payloads named "protocol numbers".
-
-  This is effectively a "router" type: it expects to get protocol number as a parameter, and then invokes relevant type parser based on that parameter.
-
-                 d[0]                              d[1]
-  7   6   5   4   3   2   1   0     7   6   5   4   3   2   1   0
-  a4  a3  a2  a1  a0  b8  b7  b6    b5  b4  b3  b2  b1  b0  c1  c0
-  ─────────┬────────  ─────────────────┬──────────────────  ───┬──
-           a                           b                       c
- │ ───────────────────────────> │  │ ───────────────────────────> │
-        parsing direction       ╷  ↑
-                                └┄┄┘
-doc-ref: https://github.com/velocet/iown-homecontrol
-params:
-  - id: protocol_num
-    type: u1
-    doc: Protocol number as an integer.
+  endian: be
+  doc: |
+    describes a io-homecontrol packet (Layer 3; Network)
+    It starts with the SFD (Start Frame Delimiter) and end with the checksum (CRC-16)
+    The encoding is big-endian (except the 16-bit checksum)
+    example: ff 33 f8 00 00 00 7f 70 87 58 00 01 61 d4 00 80 c8 00 00 3b d5 05 52 68 75 49 9c 7e 72
+             |___|       |______| |______|                            |___|                   |___|
+              SFD         target   source                            counter                   crc
 seq:
-  - id: preamble
-    contents: [0x55, 0x55, 0x55, 0x55]
-  - id: sync_word
+  - id: sfd
+    doc: Start Frame Delimiter
     contents: [0xFF, 0x33]
-  - id: header
-    type: struct_header
-    size: 2
-  - id: body
-    type:
-      switch-on: protocol
-      cases:
-        'command_enum::000_acei': parameter_acei
-        'command_enum::032_prv': parameter_prv
-        'command_enum::255_undefined': parameter_na
-instances:
-  controlbyte1:
-    pos: 0
-    type:
-    value: protocol_num
-    enum: command_enum
-  controlbyte1:
-    value: protocol_num
-    enum: command_enum
+  - id: control1
+    type: control1
+  - id: control2
+    type: control2
+  - id: target_id
+    type: b24
+  - id: source_id
+    type: b24
+  - id: command
+    type: u1
+    enum: command
+  - id: parameter
+    doc: payload_length - bytes_already_parsed - counter - mac
+    size: control1.payload_length - 8 - 2 - 6
+  - id: counter
+    type: u2
+  - id: mac
+    size: 6
+  - id: checksum
+    doc: CRC-16/KERMIT
+    type: u2le
 
-    value: protocol_num
-    enum: command_enum
 types:
-  struct_header:
-    meta:
-      bit-endian: be
+  control1:
     seq:
-      - id: control_byte_1
-        doc: |
-                     d[0]
-          7   6   5   4   3   2   1   0
-          v3  v2  v1  v0  h3  h2  h1  h0
-          ───────┬──────  ───────┬──────
-              version       len_header
-        size: 1
-        type: header_byte_1
-        seq:
-          - id: version
-            type: b4
-          - id: length
-            type: b4
-      - id: control_byte_2
-        size: 1
-        type: header_byte_2
-  parameter_acei:
-    doc: Standard Parameter (Command) with a Main Parameter and optional Functional Parameter
+    - id: order
+      type: b2
+      enum: order
+    - id: mode
+      type: b1
+      enum: mode
+    - id: payload_length
+      type: b5
+  control2:
+    doc: Extended Frame Information
     seq:
-      - id: next_header_type
-        type: u1
-      - id: hdr_ext_len
-        type: u1
-      - id: body
-        size: hdr_ext_len - 1
-      - id: next_header
-        type: protocol_body(next_header_type)
-  parameter_prv:
-    doc: Dummy type for IPv6 "no next header" type, which signifies end of headers chain.
-  parameter_na:
-    doc: Reserved or Undefined Parameter
+    - id: use_beacon
+      type: b1
+    - id: routed
+      type: b1
+    - id: low_power_mode
+      type: b1
+    - id: ack
+      type: b1
+    - id: unknown
+      type: b2
+    - id: protocol_version
+      type: b2
+
 enums:
-  command_enum:
-    00: 000_acei
-    20: 032_prv
-    255: 255_undefined
-
-
-meta:
-  id: io_homecontrol
-  title: io-homecontrol Frame
-  endian: le
-  xref:
-    rfc: 791
-    wikidata: Q11103
-  license: CC0-1.0
-  ks-version: 0.8
-  imports:
-    - /network/protocol_body
-seq:
-  - id: control_byte_1
-    size: 1
-  - id: control_byte_2
-    size: 1
-  - id: total_length
-    type: u2be
-  - id: hmac
-    size: 2
-  - id: ttl
-    type: u1
-  - id: data
-    type: u1
-  - id: packet_checksum
-    size: 2
-  - id: src_node_addr
-    size: 4
-  - id: dst_node_addr
-    size: 4
-  - id: options
-    type: ipv4_options
-    size: ihl_bytes - 20
-  - id: body
-    size: total_length - ihl_bytes
-    type: protocol_body(protocol)
-instances:
-  version:
-    value: (b1 & 0xf0) >> 4
-  ihl:
-    value: b1 & 0xf
-  ihl_bytes:
-    value: ihl * 4
-types:
-  ipv4_options:
-    seq:
-      - id: entries
-        type: ipv4_option
-        repeat: eos
-  ipv4_option:
-    seq:
-      - id: b1
-        type: u1
-      - id: len
-        type: u1
-      - id: body
-        size: 'len > 2 ? len - 2 : 0'
-    instances:
-      copy:
-        value: (b1 & 0b10000000) >> 7
-      opt_class:
-        value: (b1 & 0b01100000) >> 5
-      number:
-        value: (b1 & 0b00011111)
+  order:
+    0: single
+    1: next_in_series
+    2: next_in_parallel
+    3: command_group_end
+  mode:
+    0: two_way
+    1: one_way
+  command:
+    0x00: execute_function
+    0x01: activate_mode
+    0x02: direct_command
+    0x03: private_command
+    0x04: private_command_answer
+    0x28: discover
+    0x29: discover_answer
+    0x2a: discover_remote
+    0x2b: discover_remote_answer
+    0x2c: discover_actuator_confirmation
+    0x2d: discover_confirmation_ack
+    0x30: send_key
+    0x31: ask_challenge
+    0x32: key_transfer
+    0x33: key_transfer_ack
+    0x36: address_request
+    0x37: address_answer
+    0x38: launch_key_transfer
+    0x39: remove_controller
+    0x3c: challenge_request
+    0x3d: challenge_response
+    0x46: script_upload
+    0x47: download_config
+    0x4a: rename_file
+    0x50: get_name
+    0x51: get_name_answer
+    0x52: write_name
+    0x53: write_name_ack
+    0x54: get_general_info_1
+    0x55: general_info_1_answer
+    0x56: get_general_info_2
+    0x57: general_info_2_answer
+    0xe0: bootloader_command
+    0xe1: bootloader_device
+    0xf0: send_raw_message
+    0xf2: reboot
+    0xf3: service_status_ack


### PR DESCRIPTION
Add a kaitai schema for io-homecontrol packets from my [own research](https://github.com/henrythasler/sdr/tree/master/velux) based on the documentation that is available in this repository and in the [rtl_433 project](https://github.com/merbanan/rtl_433/blob/master/src/devices/somfy_iohc.c). Can be extended in the future to include decoding of the command parameters. The enums are limited to those that are considered reliable (not marked with a "?").

